### PR TITLE
  Stabilize iOS Safari first-load and add caching headers

### DIFF
--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,1 +1,1 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{"name":"The Cube of Space","short_name":"Cube of Space","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#191919","background_color":"#191919","display":"standalone"}

--- a/src/components/cube-of-space-scene.tsx
+++ b/src/components/cube-of-space-scene.tsx
@@ -32,6 +32,7 @@ import { FaceLabels } from './face-labels';
 import { FacePlanes } from './face-planes';
 import { GamepadControls } from './gamepad-controls';
 import { MotherLabels } from './mother-labels';
+import { WebGLContextRecovery } from './webgl-context-recovery';
 import { WireCube } from './wire-cube';
 
 export function CubeOfSpaceScene(): React.JSX.Element {
@@ -313,6 +314,7 @@ export function CubeOfSpaceScene(): React.JSX.Element {
           gl.setClearColor(0x000000, 0); // transparent clear color
         }}
       >
+        <WebGLContextRecovery />
         <ambientLight intensity={0.5} />
         <directionalLight position={[5, 8, 5]} intensity={0.9} />
         <OrbitControls

--- a/src/components/rich-label.tsx
+++ b/src/components/rich-label.tsx
@@ -21,6 +21,7 @@ import {
   createHebrewLabelTexture,
   createStructuredHebrewLabel,
 } from '../utils/canvas-texture';
+import { withTextureSlot } from '../utils/texture-queue';
 
 export type RichLabelProps = {
   // Content
@@ -138,62 +139,68 @@ function RichLabelComponent({
     const abortController = new AbortController();
     let currentTexture: THREE.Texture | null = null;
 
-    // Use custom canvas config if provided, otherwise use Hebrew label helper
-    const texturePromise = canvasConfig
-      ? createCanvasTexture({
-          ...canvasConfig,
-          useOptimizedFormat:
-            canvasConfig.useOptimizedFormat ?? useMemoryOptimization,
-          targetResolution:
-            canvasConfig.targetResolution ??
-            (useMemoryOptimization
-              ? {
-                  width: Math.min(canvasConfig.width, 600),
-                  height: Math.min(canvasConfig.height, 480),
-                }
-              : undefined),
-          signal: abortController.signal,
-        })
-      : letterName && assocGlyph && assocName
-        ? createStructuredHebrewLabel(
-            hebrewLetter ?? '',
-            letterName,
-            assocGlyph,
-            assocName,
-            title,
-            {
-              width,
-              height,
-              color,
-              background,
-              hebrewFont,
-              uiFont,
-              imagePath,
-              useMemoryOptimization,
+    // Use custom canvas config if provided, otherwise use Hebrew label helper.
+    // Wrap factory call in withTextureSlot so canvas allocation only happens
+    // once a queue slot is held — prevents boot-time memory spike on iOS.
+    const texturePromise = withTextureSlot(
+      () =>
+        canvasConfig
+          ? createCanvasTexture({
+              ...canvasConfig,
+              useOptimizedFormat:
+                canvasConfig.useOptimizedFormat ?? useMemoryOptimization,
+              targetResolution:
+                canvasConfig.targetResolution ??
+                (useMemoryOptimization
+                  ? {
+                      width: Math.min(canvasConfig.width, 600),
+                      height: Math.min(canvasConfig.height, 480),
+                    }
+                  : undefined),
               signal: abortController.signal,
-              colorName,
-              colorValue,
-              note,
-              significance,
-              gematria,
-              alchemy,
-              intelligence,
-              showColorBorders,
-              outerPlanet,
-              outerPlanetGlyph,
-            }
-          )
-        : createHebrewLabelTexture(hebrewLetter ?? '', title, subtitle, {
-            width,
-            height,
-            color,
-            background,
-            hebrewFont,
-            uiFont,
-            imagePath,
-            useMemoryOptimization,
-            signal: abortController.signal,
-          });
+            })
+          : letterName && assocGlyph && assocName
+            ? createStructuredHebrewLabel(
+                hebrewLetter ?? '',
+                letterName,
+                assocGlyph,
+                assocName,
+                title,
+                {
+                  width,
+                  height,
+                  color,
+                  background,
+                  hebrewFont,
+                  uiFont,
+                  imagePath,
+                  useMemoryOptimization,
+                  signal: abortController.signal,
+                  colorName,
+                  colorValue,
+                  note,
+                  significance,
+                  gematria,
+                  alchemy,
+                  intelligence,
+                  showColorBorders,
+                  outerPlanet,
+                  outerPlanetGlyph,
+                }
+              )
+            : createHebrewLabelTexture(hebrewLetter ?? '', title, subtitle, {
+                width,
+                height,
+                color,
+                background,
+                hebrewFont,
+                uiFont,
+                imagePath,
+                useMemoryOptimization,
+                signal: abortController.signal,
+              }),
+      abortController.signal
+    );
 
     texturePromise
       .then((tex) => {
@@ -473,10 +480,14 @@ function ComplexRichLabelComponent({
     const abortController = new AbortController();
     let currentTexture: THREE.Texture | null = null;
 
-    createCanvasTexture({
-      ...canvasConfig,
-      signal: abortController.signal,
-    })
+    withTextureSlot(
+      () =>
+        createCanvasTexture({
+          ...canvasConfig,
+          signal: abortController.signal,
+        }),
+      abortController.signal
+    )
       .then((tex) => {
         // Check if component is still mounted
         if (!abortController.signal.aborted) {
@@ -491,7 +502,7 @@ function ComplexRichLabelComponent({
           tex.dispose();
         }
       })
-      .catch((error) => {
+      .catch((error: unknown) => {
         // Silently ignore AbortErrors as they are expected during unmount
         if (error instanceof Error && error.name === 'AbortError') {
           return;

--- a/src/components/webgl-context-recovery.tsx
+++ b/src/components/webgl-context-recovery.tsx
@@ -1,0 +1,37 @@
+/**
+ * @fileoverview WebGL context loss recovery — when iOS Safari evicts the GL
+ * context under memory pressure the canvas would otherwise silently render
+ * blank. This listens for restoration and reloads the page so the user gets
+ * a working scene instead of a black void.
+ */
+
+// src/components/webgl-context-recovery.tsx
+import { useThree } from '@react-three/fiber';
+import * as React from 'react';
+
+export function WebGLContextRecovery(): null {
+  const gl = useThree((state) => state.gl);
+
+  React.useEffect(() => {
+    const dom = gl.domElement;
+
+    const onLost = (event: Event): void => {
+      // preventDefault tells the browser we want a 'webglcontextrestored' event
+      event.preventDefault();
+      console.warn('WebGL context lost');
+    };
+    const onRestored = (): void => {
+      console.warn('WebGL context restored — reloading');
+      window.location.reload();
+    };
+
+    dom.addEventListener('webglcontextlost', onLost, false);
+    dom.addEventListener('webglcontextrestored', onRestored, false);
+    return () => {
+      dom.removeEventListener('webglcontextlost', onLost);
+      dom.removeEventListener('webglcontextrestored', onRestored);
+    };
+  }, [gl]);
+
+  return null;
+}

--- a/src/config/app-config.ts
+++ b/src/config/app-config.ts
@@ -82,6 +82,13 @@ export const APP_CONFIG = {
       /** DPR range for desktop [min, max] */
       desktop: [1, 2] as const,
     },
+    /**
+     * Max DPR for off-screen label canvases. Capped at 1.5 so a label canvas
+     * matches the R3F mobile framebuffer — on iPhone 14 Pro Max (devicePixelRatio
+     * 3) this avoids a ~4x CPU memory spike per label during boot that caused
+     * intermittent first-load failures.
+     */
+    labelCanvasMaxDpr: 1.5,
   },
 
   /**

--- a/src/utils/canvas-texture.ts
+++ b/src/utils/canvas-texture.ts
@@ -6,6 +6,7 @@
 // src/utils/canvas-texture.ts
 import * as THREE from 'three';
 
+import { APP_CONFIG } from '../config/app-config';
 import {
   LABEL_HEIGHT_NO_IMAGE,
   LABEL_HEIGHT_WITH_IMAGE,
@@ -15,9 +16,78 @@ import {
 import { createAlphaMaskTexture, createOptimizedCanvas } from './texture-atlas';
 
 /**
- * Module-level image cache to avoid repeated loading and decoding
+ * Module-level image cache. The cached promise is *signal-less* and shared
+ * across callers — each caller races the shared load against its own
+ * AbortSignal in loadImageWithSignal() rather than passing its signal into
+ * the cached load. This keeps one component's abort from rejecting every
+ * other caller of the same src, and avoids storing a permanently-rejected
+ * promise (the bug that previously required 2-3 page refreshes on iOS).
  */
 const imageCache = new Map<string, Promise<HTMLImageElement>>();
+
+function loadImageShared(src: string): Promise<HTMLImageElement> {
+  const cached = imageCache.get(src);
+  if (cached) return cached;
+
+  const promise = new Promise<HTMLImageElement>((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => {
+      // Only evict on real load failure — lets the next caller retry.
+      imageCache.delete(src);
+      const error = new Error(`Failed to load image: ${src}`);
+      error.name = 'ImageLoadError';
+      reject(error);
+    };
+    img.src = src;
+  });
+
+  imageCache.set(src, promise);
+  return promise;
+}
+
+function loadImageWithSignal(
+  src: string,
+  signal?: AbortSignal
+): Promise<HTMLImageElement> {
+  if (signal?.aborted) {
+    const error = new Error('Image loading aborted');
+    error.name = 'AbortError';
+    return Promise.reject(error);
+  }
+
+  const shared = loadImageShared(src);
+  if (!signal) return shared;
+
+  return new Promise<HTMLImageElement>((resolve, reject) => {
+    const onAbort = (): void => {
+      const error = new Error('Image loading aborted');
+      error.name = 'AbortError';
+      reject(error);
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+
+    shared.then(
+      (img) => {
+        signal.removeEventListener('abort', onAbort);
+        // Re-check abort: image resolution and abort can land in the same
+        // microtask turn; if abort already fired we should reject rather
+        // than hand a texture to a torn-down component.
+        if (signal.aborted) {
+          const error = new Error('Image loading aborted');
+          error.name = 'AbortError';
+          reject(error);
+          return;
+        }
+        resolve(img);
+      },
+      (error: unknown) => {
+        signal.removeEventListener('abort', onAbort);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    );
+  });
+}
 
 export type TextStyle = {
   fontSize: number;
@@ -113,7 +183,8 @@ export function createCanvasTexture(
       isBlackAndWhite
     );
 
-    const dpr = config.devicePixelRatio ?? window.devicePixelRatio ?? 1;
+    const rawDpr = config.devicePixelRatio ?? window.devicePixelRatio ?? 1;
+    const dpr = Math.min(rawDpr, APP_CONFIG.rendering.labelCanvasMaxDpr);
 
     // Set canvas dimensions with device pixel ratio for crisp rendering
     canvas.width = renderWidth * dpr;
@@ -341,58 +412,9 @@ async function loadImages(
   if (imageConfigs.length === 0) {
     return [];
   }
-
-  // Check if already aborted
-  if (signal?.aborted) {
-    const error = new Error('Image loading aborted');
-    error.name = 'AbortError';
-    throw error;
-  }
-
-  const promises = imageConfigs.map((config) => {
-    // Check cache first
-    if (imageCache.has(config.src)) {
-      return imageCache.get(config.src)!;
-    }
-
-    // Create and cache the promise with abort support
-    const imagePromise = new Promise<HTMLImageElement>((resolve, reject) => {
-      if (signal?.aborted) {
-        const error = new Error('Image loading aborted');
-        error.name = 'AbortError';
-        reject(error);
-        return;
-      }
-
-      const img = new Image();
-
-      // Set up abort handler
-      const abortHandler = (): void => {
-        img.src = ''; // Cancel image loading
-        const error = new Error('Image loading aborted');
-        error.name = 'AbortError';
-        reject(error);
-      };
-      signal?.addEventListener('abort', abortHandler, { once: true });
-
-      img.onload = () => {
-        signal?.removeEventListener('abort', abortHandler);
-        resolve(img);
-      };
-      img.onerror = () => {
-        signal?.removeEventListener('abort', abortHandler);
-        const error = new Error(`Failed to load image: ${config.src}`);
-        error.name = 'ImageLoadError';
-        reject(error);
-      };
-      img.src = config.src;
-    });
-
-    imageCache.set(config.src, imagePromise);
-    return imagePromise;
-  });
-
-  return Promise.all(promises);
+  return Promise.all(
+    imageConfigs.map((config) => loadImageWithSignal(config.src, signal))
+  );
 }
 
 /**

--- a/src/utils/texture-queue.ts
+++ b/src/utils/texture-queue.ts
@@ -1,0 +1,96 @@
+/**
+ * @fileoverview Concurrency-limited texture creation queue. Smooths the boot
+ * memory spike on iOS Safari by ensuring at most MAX_CONCURRENT label
+ * canvases are being rasterized + uploaded to the GPU at once.
+ */
+
+// src/utils/texture-queue.ts
+
+const MAX_CONCURRENT = 4;
+
+let inFlight = 0;
+
+interface Waiter {
+  resolve: () => void;
+  reject: (error: Error) => void;
+  settled: boolean;
+}
+
+const waiters: Waiter[] = [];
+
+function drainNext(): void {
+  while (waiters.length > 0) {
+    const next = waiters.shift();
+    if (!next || next.settled) continue;
+    next.resolve();
+    return;
+  }
+}
+
+/**
+ * Run `fn` once a slot is available, never exceeding MAX_CONCURRENT in-flight
+ * calls. Honors `signal`: aborting before the slot is acquired rejects with
+ * AbortError and removes the waiter from the queue. The factory `fn` itself
+ * is responsible for re-checking the signal once it runs.
+ *
+ * IMPORTANT: callers must pass `() => createX(...)`, not a pre-built promise —
+ * factories like createCanvasTexture allocate canvases synchronously, so they
+ * must not run until a slot is held.
+ */
+export async function withTextureSlot<T>(
+  fn: () => Promise<T>,
+  signal?: AbortSignal
+): Promise<T> {
+  if (signal?.aborted) {
+    const error = new Error('Aborted before slot acquired');
+    error.name = 'AbortError';
+    throw error;
+  }
+
+  if (inFlight >= MAX_CONCURRENT) {
+    await new Promise<void>((resolveOuter, rejectOuter) => {
+      const waiter: Waiter = {
+        resolve: () => undefined,
+        reject: () => undefined,
+        settled: false,
+      };
+
+      const onAbort = (): void => {
+        if (waiter.settled) return;
+        waiter.settled = true;
+        const idx = waiters.indexOf(waiter);
+        if (idx >= 0) waiters.splice(idx, 1);
+        const error = new Error('Aborted while waiting for slot');
+        error.name = 'AbortError';
+        rejectOuter(error);
+      };
+
+      // Wrap resolve/reject so they only fire once and always remove the
+      // abort listener — prevents a late-firing abort from rejecting an
+      // already-resolved waiter.
+      waiter.resolve = (): void => {
+        if (waiter.settled) return;
+        waiter.settled = true;
+        signal?.removeEventListener('abort', onAbort);
+        resolveOuter();
+      };
+      waiter.reject = (error: Error): void => {
+        if (waiter.settled) return;
+        waiter.settled = true;
+        signal?.removeEventListener('abort', onAbort);
+        rejectOuter(error);
+      };
+
+      waiters.push(waiter);
+      signal?.addEventListener('abort', onAbort, { once: true });
+    });
+  }
+
+  inFlight++;
+  try {
+    return await fn();
+  } finally {
+    inFlight--;
+    drainNext();
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,31 @@
+{
+  "headers": [
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/fonts/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=2592000, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/images/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=2592000, must-revalidate"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
  iPhone 14 Pro Max needed 2-3 refreshes before the page would load. Three
  stacked issues caused a memory spike at boot that Safari handled
  unreliably:

    - Label canvases used the raw window.devicePixelRatio (3 on Pro Max), quadrupling CPU memory per label vs. the 1.5 the renderer actually samples. Cap label canvas DPR at 1.5 via APP_CONFIG.
    - All ~40 labels rasterized in parallel. Add an abort-aware semaphore (withTextureSlot) so at most 4 run at once; the factory call must sit inside the slot since createCanvasTexture allocates synchronously.
    - imageCache stored each caller's promise complete with its own AbortSignal, so one component's unmount rejected every later caller of the same src and the rejection stayed cached forever (matching the "second refresh works" symptom). Cache is now a signal-less shared loader; each caller races it against its own signal.

  Add a WebGLContextRecovery component (useThree + useEffect with proper
  cleanup) that reloads when the context is restored, turning a silent
  black screen under memory pressure into a single auto-refresh.

  vercel.json sets immutable 1y caching on hashed /assets/* and 30-day
  must-revalidate on /fonts/* and /images/* so refreshes don't redownload
  ~7MB of Tarot PNGs and ~1MB of fonts.

  site.webmanifest gets a real name and #191919 theme/background to match
  the dark gradient and avoid the white flash on first paint.